### PR TITLE
fixed caption is not recognized as content

### DIFF
--- a/datadict_grt.py
+++ b/datadict_grt.py
@@ -371,7 +371,7 @@ def save(html, path):
 def table_as_html(table):
     """Return table as an HTML table."""
     markup = "<table id='{0}'>".format(table.name)
-    markup += "<caption>{0}</caption>".format(table.name)
+    markup += "<h1>{0}</h1>".format(table.name)
     markup += "<tr><td colspan='12'>{0}</td></tr>".format(escape(table.comment))
     markup += html_table_header()
 


### PR DESCRIPTION
hey @linuxwebexpert this works really well for me but I'm going to recommend this change I made to a fork of your script.

I believe h1 is better semantically as a header for each table than caption in html terms, secondly, when you copy and paste this into various applications all the table names are missing.

the reason is because the caption tags are not recognized as content.

Visually, this appears to have a similar outcome as to what you were trying to achieve with table captions and is import compatible into editors like google sheets and microsoft excel.